### PR TITLE
#19 Remove java types imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>net.coru</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <packaging>maven-plugin</packaging>
 
   <name>AsyncApi - OpenApi Code Generator Maven Plugin</name>

--- a/src/main/java/net/coru/api/generator/plugin/openapi/template/TemplateFactory.java
+++ b/src/main/java/net/coru/api/generator/plugin/openapi/template/TemplateFactory.java
@@ -20,6 +20,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -44,11 +45,14 @@ public class TemplateFactory {
 
   private final HashMap<String, Schema> itemSchema = new HashMap<>();
 
+  private final List<String> basicDataTypes = List.of("Integer", "Long", "Float", "Double", "Boolean", "String", "Char", "Byte", "Short");
+
   public TemplateFactory() {
     cfg.setTemplateLoader(new ClasspathTemplateLoader());
     cfg.setDefaultEncoding("UTF-8");
     cfg.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
     cfg.setLogTemplateExceptions(true);
+    root.put("checkBasicTypes", basicDataTypes);
 
   }
 

--- a/src/main/resources/templates/openapi/template.ftlh
+++ b/src/main/resources/templates/openapi/template.ftlh
@@ -22,14 +22,18 @@ import java.util.Map;
     <#list operation.requestObjects as request>
       <#list request.contentObject as content>
         <#if content.importName?? && (!imports?seq_contains(content.importName))>
-        		<#assign imports = imports+[content.importName]>
+          <#if (!checkBasicTypes?seq_contains(content.importName))>
+            <#assign imports = imports+[content.importName]>
+          </#if>
         </#if>
       </#list>
     </#list>
     <#list operation.responseObjects as response>
       <#list response.contentObject as content>
         <#if content.importName?? && (!imports?seq_contains(content.importName))>
+          <#if (!checkBasicTypes?seq_contains(content.importName))>
             <#assign imports = imports+[content.importName]>
+          </#if>
         </#if>
       </#list>
     </#list>

--- a/src/main/resources/templates/openapi/templateCallRestClient.ftlh
+++ b/src/main/resources/templates/openapi/templateCallRestClient.ftlh
@@ -13,14 +13,18 @@ import java.util.Map;
     <#list operation.requestObjects as request>
       <#list request.contentObject as content>
         <#if (!imports?seq_contains(content.refName))>
+          <#if (!checkBasicTypes?seq_contains(content.refName))>
         		<#assign imports = imports+[content.refName]>
+          </#if>
         </#if>
       </#list>
     </#list>
     <#list operation.responseObjects as response>
       <#list response.contentObject as content>
         <#if (!imports?seq_contains(content.refName))>
+          <#if (!checkBasicTypes?seq_contains(content.refName))>
             <#assign imports = imports+[content.refName]>
+          </#if>
         </#if>
       </#list>
     </#list>

--- a/src/main/resources/templates/openapi/templateCallWebClient.ftlh
+++ b/src/main/resources/templates/openapi/templateCallWebClient.ftlh
@@ -13,14 +13,18 @@ import java.util.Map;
     <#list operation.requestObjects as request>
       <#list request.contentObject as content>
         <#if (!imports?seq_contains(content.refName))>
-        		<#assign imports = imports+[content.refName]>
+          <#if (!checkBasicTypes?seq_contains(content.refName))>
+            <#assign imports = imports+[content.refName]>
+          </#if>
         </#if>
       </#list>
     </#list>
     <#list operation.responseObjects as response>
       <#list response.contentObject as content>
         <#if (!imports?seq_contains(content.refName))>
+          <#if (!checkBasicTypes?seq_contains(content.refName))>
             <#assign imports = imports+[content.refName]>
+          </#if>
         </#if>
       </#list>
     </#list>

--- a/src/main/resources/templates/openapi/templateReactive.ftlh
+++ b/src/main/resources/templates/openapi/templateReactive.ftlh
@@ -27,14 +27,18 @@ import java.util.Map;
     <#list operation.requestObjects as request>
       <#list request.contentObject as content>
         <#if content.importName?? && (!imports?seq_contains(content.importName))>
-        		<#assign imports = imports+[content.importName]>
+          <#if (!checkBasicTypes?seq_contains(content.importName))>
+            <#assign imports = imports+[content.importName]>
+          </#if>
         </#if>
       </#list>
     </#list>
     <#list operation.responseObjects as response>
       <#list response.contentObject as content>
         <#if content.importName?? && (!imports?seq_contains(content.importName))>
+          <#if (!checkBasicTypes?seq_contains(content.importName))>
             <#assign imports = imports+[content.importName]>
+          </#if>
         </#if>
       </#list>
     </#list>


### PR DESCRIPTION
As a developer, I don't want my project to have imports for Java data types as if they were part of my model, to avoid possible errors and problems during the compilation and execution.