### PR TITLE
115 Fix ModelClassException creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ As commented above, they both could be used at the same time, setting a double
 <plugin>
   <groupId>net.coru</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-  <version>2.3.0</version>
+  <version>3.0.1</version>
   <executions>
     <execution>
       <id>asyncapi</id>
@@ -112,7 +112,7 @@ which the plugin is designed.
 <plugin>
 <groupId>net.coru</groupId>
 <artifactId>scs-multiapi-maven-plugin</artifactId>
-<version>2.3.0</version>
+<version>3.0.1</version>
 <executions>
   <execution>
     <phase>generate-sources</phase>
@@ -478,7 +478,7 @@ file. Here is an example of a basic configuration:
 <plugin>
   <groupId>net.coru</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-  <version>2.3.0</version>
+  <version>3.0.1</version>
   <executions>
     <execution>
         <goals>
@@ -567,11 +567,11 @@ RestClient and the WebClient will be located, if this option is set in any
 of the fileSpecs, and the name of the folder where the generated sources will
 be saved in the api of the project.
 
-| Name                                                | Description                                                                                                                                                                                                                                                                    | Example                              |
-|-----------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
-| clientPackage                                       | Path where the RestClient and/or WebClient are located                                                                                                                                                                                                                         | net.coru.apigenerator.openapi.client |
-| [generatedSourcesFolder](#generated-sources-folder) | Name of the folder, inside `target`, where the files will be located. By defaut it's `generated-sources`                                                                                                                                                                       | generated-sources                    |
-| overWriteModel                                      | Boolean value to decide if you want your models to be overwritten if two or more models have the same name. True means that models will be overwritten and if false is set, it will throw an exception if two models share the same name.It is initialized to false by default | true                                 |
+| Name                                                | Description                                                                                                                                                                                                                                                                     | Example                              |
+|-----------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| clientPackage                                       | Path where the RestClient and/or WebClient are located                                                                                                                                                                                                                          | net.coru.apigenerator.openapi.client |
+| [generatedSourcesFolder](#generated-sources-folder) | Name of the folder, inside `target`, where the files will be located. By defaut it's `generated-sources`                                                                                                                                                                        | generated-sources                    |
+| overwriteModel                                      | Boolean value to decide if you want your models to be overwritten if two or more models have the same name. True means that models will be overwritten and if false is set, it will throw an exception if two models share the same name. It is initialized to false by default | false                                |
 
 We must clarify that the options to make calls are configured under the
 RestClient or WebClient specifications as indicated above in the configuration

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>net.coru</groupId>
   <artifactId>scs-multiapi-maven-plugin</artifactId>
-  <version>3.0.0</version>
+  <version>3.0.1</version>
   <packaging>maven-plugin</packaging>
 
   <name>AsyncApi - OpenApi Code Generator Maven Plugin</name>

--- a/src/main/java/net/coru/api/generator/plugin/openapi/template/TemplateFactory.java
+++ b/src/main/java/net/coru/api/generator/plugin/openapi/template/TemplateFactory.java
@@ -58,7 +58,7 @@ public class TemplateFactory {
     final Path pathToExceptionPackage = fileToSave.toPath().resolve("exception");
     pathToExceptionPackage.toFile().mkdirs();
     final String pathToSaveMainClass = pathToExceptionPackage.resolve("ModelClassException.java").toString();
-    writeTemplateToFile(TemplateIndexConstants.TEMPLATE_MODEL_EXCEPTION, root, pathToSaveMainClass);
+    writeTemplateToFile(TemplateIndexConstants.TEMPLATE_MODEL_EXCEPTION, root, pathToSaveMainClass, false);
 
   }
 
@@ -111,9 +111,14 @@ public class TemplateFactory {
   }
 
   private void writeTemplateToFile(final String templateName, final Map<String, Object> root, final String path) throws IOException, TemplateException {
+    writeTemplateToFile(templateName, root, path, true);
+  }
+
+  private void writeTemplateToFile(final String templateName, final Map<String, Object> root, final String path, final boolean checkOverwrite) throws IOException,
+                                                                                                                                                      TemplateException {
     final Template template = cfg.getTemplate(templateName);
 
-    if (!Files.exists(Path.of(path))) {
+    if (!Files.exists(Path.of(path)) || !checkOverwrite) {
       final FileWriter writer = new FileWriter(path);
       template.process(root, writer);
       writer.close();

--- a/src/test/java/net/coru/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest.java
+++ b/src/test/java/net/coru/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest.java
@@ -77,6 +77,11 @@ public class ScsMultiapiGenerationTest {
         new File("src/test/resources/net/coru/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/" + testName + "/assets/ApiTestInfoDTO.java")
     );
 
+    List<String> expectedExceptionFilenames = List.of("ModelClassException.java");
+
+    List<File> expectedExceptionFiles = List.of(new File("src/test/resources/net/coru/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/" + testName + "/assets" +
+                                                         "/ModelClassException.java"));
+
     assertThat(result).hasTarget();
     Path pathToTarget = result.getTargetProjectDirectory().toPath();
 
@@ -85,20 +90,24 @@ public class ScsMultiapiGenerationTest {
 
     Path pathToTargetApi = pathToTarget.resolve("target/" + generatedSourcesFolderName + "/apigenerator/net/coru/multifileplugin/testapi");
     Path pathToTargetModel = pathToTarget.resolve("target/" + generatedSourcesFolderName + "/apigenerator/net/coru/multifileplugin/testapi/model");
+    Path pathToTargetException = pathToTarget.resolve("target/" + generatedSourcesFolderName + "/apigenerator/net/coru/multifileplugin/testapi/model/exception");
 
     File targetConsumerDirectory = pathToTargetConsumer.toFile();
     File targetProducerDirectory = pathToTargetProducer.toFile();
     File targetApiDirectory = pathToTargetApi.toFile();
     File targetModelDirectory = pathToTargetModel.toFile();
+    File targetExceptionDirectory = pathToTargetException.toFile();
 
     checkTargetFiles(expectedFileConsumerNames, targetConsumerDirectory);
     checkTargetFiles(expectedFileProducerNames, targetProducerDirectory);
     checkTargetFiles(expectedFileNames, targetApiDirectory);
     checkTargetFiles(expectedModelFileNames, targetModelDirectory);
+    checkTargetFiles(expectedExceptionFilenames, targetExceptionDirectory);
 
     validateFiles(expectedConsumerFiles, targetConsumerDirectory);
     validateFiles(expectedProducerFiles, targetProducerDirectory);
     validateFiles(expectedFiles, targetApiDirectory);
     validateFiles(expectedModelFiles, targetModelDirectory);
+    validateFiles(expectedExceptionFiles, targetExceptionDirectory);
   }
 }

--- a/src/test/java/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest.java
+++ b/src/test/java/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Objects;
 
 import com.soebes.itf.jupiter.extension.MavenGoal;
 import com.soebes.itf.jupiter.extension.MavenJupiterExtension;
@@ -31,6 +32,8 @@ public class OpenApiGenerationTest {
 
   private final String DEFAULT_MODEL_API = "target/generated-sources/apigenerator/net/coru/multifileplugin/testapi/model";
 
+  private final String DEFAULT_EXCEPTION_API = "target/generated-sources/apigenerator/net/coru/multifileplugin/testapi/model/exception";
+
   @MavenTest
   @MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:openapi-generation")
   void testApiClientGeneration(MavenProjectResult result) throws IOException {
@@ -43,7 +46,7 @@ public class OpenApiGenerationTest {
         new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiClientGeneration/assets/ApiTestInfoDTO.java")
     );
 
-    commonTest(result, expectedFile, expectedModelFiles, DEFAULT_TARGET_API, DEFAULT_MODEL_API);
+    commonTest(result, expectedFile, expectedModelFiles, DEFAULT_TARGET_API, DEFAULT_MODEL_API, null, null);
   }
 
   @MavenTest
@@ -58,7 +61,10 @@ public class OpenApiGenerationTest {
         new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiEnumsGeneration/assets/ApiTestInfoDTO.java")
     );
 
-    commonTest(result, expectedFile, expectedModelFiles, DEFAULT_TARGET_API, DEFAULT_MODEL_API);
+    List<File> expectedExceptionFiles = List.of(
+        new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiEnumsGeneration/assets/ModelClassException.java"));
+
+    commonTest(result, expectedFile, expectedModelFiles, DEFAULT_TARGET_API, DEFAULT_MODEL_API, expectedExceptionFiles, DEFAULT_EXCEPTION_API);
   }
 
   @MavenTest
@@ -73,7 +79,7 @@ public class OpenApiGenerationTest {
         new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiEnumsLombokGeneration/assets/ApiTestInfoDTO.java")
     );
 
-    commonTest(result, expectedFile, expectedModelFiles, DEFAULT_TARGET_API, DEFAULT_MODEL_API);
+    commonTest(result, expectedFile, expectedModelFiles, DEFAULT_TARGET_API, DEFAULT_MODEL_API, null, null);
   }
 
   @MavenTest
@@ -88,7 +94,10 @@ public class OpenApiGenerationTest {
         new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiPathParameterGeneration/assets/ApiTestInfoDTO.java")
     );
 
-    commonTest(result, expectedFile, expectedModelFiles, DEFAULT_TARGET_API, DEFAULT_MODEL_API);
+    List<File> expectedExceptionFiles = List.of(
+        new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiPathParameterGeneration/assets/ModelClassException.java"));
+
+    commonTest(result, expectedFile, expectedModelFiles, DEFAULT_TARGET_API, DEFAULT_MODEL_API, expectedExceptionFiles, DEFAULT_EXCEPTION_API);
   }
 
   @MavenTest
@@ -102,7 +111,7 @@ public class OpenApiGenerationTest {
         new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testMultipleRefGeneration/assets/MessageDTO.java")
     );
 
-    commonTest(result, expectedFile, expectedModelFiles, DEFAULT_TARGET_API, DEFAULT_MODEL_API);
+    commonTest(result, expectedFile, expectedModelFiles, DEFAULT_TARGET_API, DEFAULT_MODEL_API, null, null);
   }
 
   @MavenTest
@@ -117,11 +126,15 @@ public class OpenApiGenerationTest {
         new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiReactiveGeneration/assets/ApiTestInfoDTO.java")
     );
 
-    commonTest(result, expectedFile, expectedModelFiles, DEFAULT_TARGET_API, DEFAULT_MODEL_API);
+    List<File> expectedExceptionFiles = List.of(
+        new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiReactiveGeneration/assets/ModelClassException.java"));
+
+    commonTest(result, expectedFile, expectedModelFiles, DEFAULT_TARGET_API, DEFAULT_MODEL_API, expectedExceptionFiles, DEFAULT_EXCEPTION_API);
   }
 
-  private void commonTest(final MavenProjectResult result, final List<File> expectedFile, final List<File> expectedModelFiles, final String targetApi, final String targetModel)
-      throws IOException {
+  private void commonTest(
+      final MavenProjectResult result, final List<File> expectedFile, final List<File> expectedModelFiles, final String targetApi, final String targetModel,
+      final List<File> expectedExceptionFiles, final String targetException) throws IOException {
     assertThat(result).hasTarget();
     Path pathToTarget = result.getTargetProjectDirectory().toPath();
     Path pathToTargetApi = pathToTarget.resolve(targetApi);
@@ -135,6 +148,13 @@ public class OpenApiGenerationTest {
 
     validateFiles(expectedFile, targetApiFolder);
     validateFiles(expectedModelFiles, targetModelFolder);
+
+    if (Objects.nonNull(expectedExceptionFiles)) {
+      Path pathToTargetException = pathToTarget.resolve(targetException);
+      File targetModelException = pathToTargetException.toFile();
+      assertThat(targetModelException).isNotEmptyDirectory();
+      validateFiles(expectedExceptionFiles, targetModelException);
+    }
   }
 
   @MavenTest
@@ -145,14 +165,22 @@ public class OpenApiGenerationTest {
         new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiTagsGeneration/assets/TestTagFirstApi.java"),
         new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiTagsGeneration/assets/TestTagSecondApi.java"));
 
+    List<File> expectedExceptionFiles = List.of(
+        new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiTagsGeneration/assets/ModelClassException.java"));
+
     assertThat(result).hasTarget();
     Path pathToTarget = result.getTargetProjectDirectory().toPath();
-    pathToTarget = pathToTarget.resolve("target/generated-sources/apigenerator/net/coru/multifileplugin/testtags");
+    Path pathToTargetApi = pathToTarget.resolve("target/generated-sources/apigenerator/net/coru/multifileplugin/testtags");
+    Path pathToException = pathToTarget.resolve("target/generated-sources/apigenerator/net/coru/multifileplugin/testtags/model/exception");
 
-    File targetApiFolder = pathToTarget.toFile();
+    File targetApiFolder = pathToTargetApi.toFile();
     assertThat(targetApiFolder).isNotEmptyDirectory();
 
+    File targetExceptionFolder = pathToException.toFile();
+    assertThat(targetExceptionFolder).isNotEmptyDirectory();
+
     validateFiles(expectedModelFiles, targetApiFolder);
+    validateFiles(expectedExceptionFiles, targetExceptionFolder);
   }
 
   @MavenTest
@@ -163,10 +191,18 @@ public class OpenApiGenerationTest {
     List<File> expectedFileSecond = List.of(new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiMultiGeneration/assets" +
                                                      "/TestSecondApi.java"));
 
+    List<File> expectedExceptionFilesFirst = List.of(
+        new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiMultiGeneration/assets/ModelClassExceptionFirst.java"));
+
+    List<File> expectedExceptionFilesSecond = List.of(
+        new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiMultiGeneration/assets/ModelClassExceptionSecond.java"));
+
     assertThat(result).hasTarget();
     Path pathToTarget = result.getTargetProjectDirectory().toPath();
     Path pathToTargetFirst = pathToTarget.resolve("target/generated-sources/apigenerator/net/coru/multifileplugin/testmultifile/first");
     Path pathToTargetSecond = pathToTarget.resolve("target/generated-sources/apigenerator/net/coru/multifileplugin/testmultifile/second");
+    Path pathToExceptionFirst = pathToTarget.resolve("target/generated-sources/apigenerator/net/coru/multifileplugin/testmultifile/first/model/exception");
+    Path pathToExceptionSecond = pathToTarget.resolve("target/generated-sources/apigenerator/net/coru/multifileplugin/testmultifile/second/model/exception");
 
     File targetFirstFolder = pathToTargetFirst.toFile();
     assertThat(targetFirstFolder).isNotEmptyDirectory();
@@ -174,8 +210,16 @@ public class OpenApiGenerationTest {
     File targetSecondFolder = pathToTargetSecond.toFile();
     assertThat(targetSecondFolder).isNotEmptyDirectory();
 
+    File targetExceptionFirstFolder = pathToExceptionFirst.toFile();
+    assertThat(targetExceptionFirstFolder).isNotEmptyDirectory();
+
+    File targetExceptionSecondFolder = pathToExceptionSecond.toFile();
+    assertThat(targetExceptionSecondFolder).isNotEmptyDirectory();
+
     validateFiles(expectedFileFirst, targetFirstFolder);
     validateFiles(expectedFileSecond, targetSecondFolder);
+    validateFiles(expectedExceptionFilesFirst, targetExceptionFirstFolder);
+    validateFiles(expectedExceptionFilesSecond, targetExceptionSecondFolder);
   }
 
   @MavenTest
@@ -185,14 +229,22 @@ public class OpenApiGenerationTest {
         new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testWebClientApiGeneration/assets" +
                  "/TestApi.java"));
 
+    List<File> expectedExceptionFiles = List.of(
+        new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testWebClientApiGeneration/assets/ModelClassException.java"));
+
     assertThat(result).hasTarget();
     Path pathToTarget = result.getTargetProjectDirectory().toPath();
     Path pathToTargetFirst = pathToTarget.resolve("target/generated-sources/apigenerator/net/coru/multifileplugin/testwebclient");
+    Path pathToException = pathToTarget.resolve("target/generated-sources/apigenerator/net/coru/multifileplugin/testwebclient/model/exception");
 
     File targetFirstFolder = pathToTargetFirst.toFile();
     assertThat(targetFirstFolder).isNotEmptyDirectory();
 
+    File targetException = pathToException.toFile();
+    assertThat(targetException).isNotEmptyDirectory();
+
     validateFiles(expectedFileFirst, targetFirstFolder);
+    validateFiles(expectedExceptionFiles, targetException);
   }
 
   @MavenTest
@@ -207,10 +259,15 @@ public class OpenApiGenerationTest {
         new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testClientPackageWebClientApiGeneration/assets" +
                  "/TestHttpBasicAuth.java"));
 
+    List<File> expectedExceptionFiles = List.of(
+        new File(
+            "src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testClientPackageWebClientApiGeneration/assets/ModelClassException.java"));
+
     assertThat(result).hasTarget();
     Path pathToTarget = result.getTargetProjectDirectory().toPath();
     Path pathToTargetFirst = pathToTarget.resolve("target/generated-sources/apigenerator/net/coru/multifileplugin/testclientpackage/client");
     Path pathToTargetSecond = pathToTarget.resolve("target/generated-sources/apigenerator/net/coru/multifileplugin/testclientpackage/client/auth");
+    Path pathToException = pathToTarget.resolve("target/generated-sources/apigenerator/net/coru/multifileplugin/testclientpackage/model/exception");
 
     File targetFirstFolder = pathToTargetFirst.toFile();
     assertThat(targetFirstFolder).isNotEmptyDirectory();
@@ -218,8 +275,12 @@ public class OpenApiGenerationTest {
     File targetSecondFolder = pathToTargetSecond.toFile();
     assertThat(targetSecondFolder).isNotEmptyDirectory();
 
+    File targetException = pathToException.toFile();
+    assertThat(targetException).isNotEmptyDirectory();
+
     validateFiles(expectedFileFirst, targetFirstFolder);
     validateFiles(expectedFileSecond, targetSecondFolder);
+    validateFiles(expectedExceptionFiles, targetException);
   }
 
   @MavenTest
@@ -228,14 +289,22 @@ public class OpenApiGenerationTest {
     List<File> expectedFileFirst = List.of(new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testRestClientApiGeneration" +
                                                     "/assets/TestApi.java"));
 
+    List<File> expectedExceptionFiles = List.of(
+        new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testRestClientApiGeneration/assets/ModelClassException.java"));
+
     assertThat(result).hasTarget();
     Path pathToTarget = result.getTargetProjectDirectory().toPath();
     Path pathToTargetFirst = pathToTarget.resolve("target/generated-sources/apigenerator/net/coru/multifileplugin/testrestclient");
+    Path pathToException = pathToTarget.resolve("target/generated-sources/apigenerator/net/coru/multifileplugin/testrestclient/model/exception");
 
     File targetFirstFolder = pathToTargetFirst.toFile();
     assertThat(targetFirstFolder).isNotEmptyDirectory();
 
+    File targetException = pathToException.toFile();
+    assertThat(targetException).isNotEmptyDirectory();
+
     validateFiles(expectedFileFirst, targetFirstFolder);
+    validateFiles(expectedExceptionFiles, targetException);
   }
 
   @MavenTest
@@ -244,14 +313,22 @@ public class OpenApiGenerationTest {
     List<File> expectedFileFirst = List.of(new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testExternalRefsGeneration" +
                                                     "/assets/TestApi.java"));
 
+    List<File> expectedExceptionFiles = List.of(
+        new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testExternalRefsGeneration/assets/ModelClassException.java"));
+
     assertThat(result).hasTarget();
     Path pathToTarget = result.getTargetProjectDirectory().toPath();
     Path pathToTargetFirst = pathToTarget.resolve("target/generated-sources/apigenerator/net/coru/multifileplugin/testapi");
+    Path pathToException = pathToTarget.resolve("target/generated-sources/apigenerator/net/coru/multifileplugin/testapi/model/exception");
 
     File targetFirstFolder = pathToTargetFirst.toFile();
     assertThat(targetFirstFolder).isNotEmptyDirectory();
 
+    File targetException = pathToException.toFile();
+    assertThat(targetException).isNotEmptyDirectory();
+
     validateFiles(expectedFileFirst, targetFirstFolder);
+    validateFiles(expectedExceptionFiles, targetException);
   }
 
   @MavenTest
@@ -267,7 +344,10 @@ public class OpenApiGenerationTest {
         new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiPathWithBarsGeneration/assets/ApiTestInfoDTO.java")
     );
 
-    commonTest(result, expectedFile, expectedModelFiles, DEFAULT_TARGET_API, DEFAULT_MODEL_API);
+    List<File> expectedExceptionFiles = List.of(
+        new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiPathWithBarsGeneration/assets/ModelClassException.java"));
+
+    commonTest(result, expectedFile, expectedModelFiles, DEFAULT_TARGET_API, DEFAULT_MODEL_API, expectedExceptionFiles, DEFAULT_EXCEPTION_API);
   }
 
   @MavenTest
@@ -286,7 +366,11 @@ public class OpenApiGenerationTest {
 
     );
 
-    commonTest(result, expectedFile, expectedModelFiles, DEFAULT_TARGET_API, DEFAULT_MODEL_API);
+    List<File> expectedExceptionFiles = List.of(
+        new File(
+            "src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiParametersWithContentGeneration/assets/ModelClassException.java"));
+
+    commonTest(result, expectedFile, expectedModelFiles, DEFAULT_TARGET_API, DEFAULT_MODEL_API, expectedExceptionFiles, DEFAULT_EXCEPTION_API);
   }
 
   @MavenTest
@@ -301,7 +385,10 @@ public class OpenApiGenerationTest {
         new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testOverWriteModelTrue/assets/ApiTestInfoDTO.java")
     );
 
-    commonTest(result, expectedFile, expectedModelFiles, DEFAULT_TARGET_API, DEFAULT_MODEL_API);
+    List<File> expectedExceptionFiles = List.of(
+        new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testOverWriteModelTrue/assets/ModelClassException.java"));
+
+    commonTest(result, expectedFile, expectedModelFiles, DEFAULT_TARGET_API, DEFAULT_MODEL_API, expectedExceptionFiles, DEFAULT_EXCEPTION_API);
   }
 
   @MavenTest
@@ -329,9 +416,12 @@ public class OpenApiGenerationTest {
         new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testAllOf/assets/lombok/ApiTestInfoDTO.java")
     );
 
-    commonTest(result, expectedTestApiFile, expectedTestApiModelFiles, DEFAULT_TARGET_API, DEFAULT_MODEL_API);
+    List<File> expectedExceptionFiles = List.of(
+        new File("src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testAllOf/assets/ModelClassException.java"));
+
+    commonTest(result, expectedTestApiFile, expectedTestApiModelFiles, DEFAULT_TARGET_API, DEFAULT_MODEL_API, expectedExceptionFiles, DEFAULT_EXCEPTION_API);
     commonTest(result, expectedLombokFile, expectedLombokModelFiles, "target/generated-sources/apigenerator/net/coru/multifileplugin/lombok/testapi",
-               "target/generated-sources/apigenerator/net/coru/multifileplugin/lombok/testapi/model");
+               "target/generated-sources/apigenerator/net/coru/multifileplugin/lombok/testapi/model", null, null);
   }
 
 }

--- a/src/test/resources/net/coru/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testMultiapiGeneratedSourcesFolder/assets/ModelClassException.java
+++ b/src/test/resources/net/coru/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testMultiapiGeneratedSourcesFolder/assets/ModelClassException.java
@@ -1,0 +1,10 @@
+package net.coru.multifileplugin.testapi.model.exception;
+
+public class ModelClassException extends RuntimeException {
+
+  private static final String ERROR_MESSAGE = "There are some problems related to the entity called %s. Maybe could be caused by required fields or anyOf/oneOf restrictions";
+
+  public ModelClassException(final String modelEntity) {
+    super(String.format(ERROR_MESSAGE, modelEntity));
+  }
+}

--- a/src/test/resources/net/coru/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testScsMultiapiGeneration/assets/ModelClassException.java
+++ b/src/test/resources/net/coru/api/generator/multiapi/integration/test/ScsMultiapiGenerationTest/testScsMultiapiGeneration/assets/ModelClassException.java
@@ -1,0 +1,10 @@
+package net.coru.multifileplugin.testapi.model.exception;
+
+public class ModelClassException extends RuntimeException {
+
+  private static final String ERROR_MESSAGE = "There are some problems related to the entity called %s. Maybe could be caused by required fields or anyOf/oneOf restrictions";
+
+  public ModelClassException(final String modelEntity) {
+    super(String.format(ERROR_MESSAGE, modelEntity));
+  }
+}

--- a/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testAllOf/assets/ModelClassException.java
+++ b/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testAllOf/assets/ModelClassException.java
@@ -1,0 +1,10 @@
+package net.coru.multifileplugin.testapi.model.exception;
+
+public class ModelClassException extends RuntimeException {
+
+  private static final String ERROR_MESSAGE = "There are some problems related to the entity called %s. Maybe could be caused by required fields or anyOf/oneOf restrictions";
+
+  public ModelClassException(final String modelEntity) {
+    super(String.format(ERROR_MESSAGE, modelEntity));
+  }
+}

--- a/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiEnumsGeneration/assets/ModelClassException.java
+++ b/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiEnumsGeneration/assets/ModelClassException.java
@@ -1,0 +1,10 @@
+package net.coru.multifileplugin.testapi.model.exception;
+
+public class ModelClassException extends RuntimeException {
+
+  private static final String ERROR_MESSAGE = "There are some problems related to the entity called %s. Maybe could be caused by required fields or anyOf/oneOf restrictions";
+
+  public ModelClassException(final String modelEntity) {
+    super(String.format(ERROR_MESSAGE, modelEntity));
+  }
+}

--- a/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiMultiGeneration/assets/ModelClassExceptionFirst.java
+++ b/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiMultiGeneration/assets/ModelClassExceptionFirst.java
@@ -1,0 +1,10 @@
+package net.coru.multifileplugin.testmultifile.first.model.exception;
+
+public class ModelClassException extends RuntimeException {
+
+  private static final String ERROR_MESSAGE = "There are some problems related to the entity called %s. Maybe could be caused by required fields or anyOf/oneOf restrictions";
+
+  public ModelClassException(final String modelEntity) {
+    super(String.format(ERROR_MESSAGE, modelEntity));
+  }
+}

--- a/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiMultiGeneration/assets/ModelClassExceptionSecond.java
+++ b/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiMultiGeneration/assets/ModelClassExceptionSecond.java
@@ -1,0 +1,10 @@
+package net.coru.multifileplugin.testmultifile.second.model.exception;
+
+public class ModelClassException extends RuntimeException {
+
+  private static final String ERROR_MESSAGE = "There are some problems related to the entity called %s. Maybe could be caused by required fields or anyOf/oneOf restrictions";
+
+  public ModelClassException(final String modelEntity) {
+    super(String.format(ERROR_MESSAGE, modelEntity));
+  }
+}

--- a/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiParametersWithContentGeneration/assets/ModelClassException.java
+++ b/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiParametersWithContentGeneration/assets/ModelClassException.java
@@ -1,0 +1,10 @@
+package net.coru.multifileplugin.testapi.model.exception;
+
+public class ModelClassException extends RuntimeException {
+
+  private static final String ERROR_MESSAGE = "There are some problems related to the entity called %s. Maybe could be caused by required fields or anyOf/oneOf restrictions";
+
+  public ModelClassException(final String modelEntity) {
+    super(String.format(ERROR_MESSAGE, modelEntity));
+  }
+}

--- a/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiPathParameterGeneration/assets/ModelClassException.java
+++ b/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiPathParameterGeneration/assets/ModelClassException.java
@@ -1,0 +1,10 @@
+package net.coru.multifileplugin.testapi.model.exception;
+
+public class ModelClassException extends RuntimeException {
+
+  private static final String ERROR_MESSAGE = "There are some problems related to the entity called %s. Maybe could be caused by required fields or anyOf/oneOf restrictions";
+
+  public ModelClassException(final String modelEntity) {
+    super(String.format(ERROR_MESSAGE, modelEntity));
+  }
+}

--- a/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiPathWithBarsGeneration/assets/ModelClassException.java
+++ b/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiPathWithBarsGeneration/assets/ModelClassException.java
@@ -1,0 +1,10 @@
+package net.coru.multifileplugin.testapi.model.exception;
+
+public class ModelClassException extends RuntimeException {
+
+  private static final String ERROR_MESSAGE = "There are some problems related to the entity called %s. Maybe could be caused by required fields or anyOf/oneOf restrictions";
+
+  public ModelClassException(final String modelEntity) {
+    super(String.format(ERROR_MESSAGE, modelEntity));
+  }
+}

--- a/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiReactiveGeneration/assets/ModelClassException.java
+++ b/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiReactiveGeneration/assets/ModelClassException.java
@@ -1,0 +1,10 @@
+package net.coru.multifileplugin.testapi.model.exception;
+
+public class ModelClassException extends RuntimeException {
+
+  private static final String ERROR_MESSAGE = "There are some problems related to the entity called %s. Maybe could be caused by required fields or anyOf/oneOf restrictions";
+
+  public ModelClassException(final String modelEntity) {
+    super(String.format(ERROR_MESSAGE, modelEntity));
+  }
+}

--- a/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiTagsGeneration/assets/ModelClassException.java
+++ b/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testApiTagsGeneration/assets/ModelClassException.java
@@ -1,0 +1,10 @@
+package net.coru.multifileplugin.testtags.model.exception;
+
+public class ModelClassException extends RuntimeException {
+
+  private static final String ERROR_MESSAGE = "There are some problems related to the entity called %s. Maybe could be caused by required fields or anyOf/oneOf restrictions";
+
+  public ModelClassException(final String modelEntity) {
+    super(String.format(ERROR_MESSAGE, modelEntity));
+  }
+}

--- a/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testClientPackageWebClientApiGeneration/assets/ModelClassException.java
+++ b/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testClientPackageWebClientApiGeneration/assets/ModelClassException.java
@@ -1,0 +1,10 @@
+package net.coru.multifileplugin.testclientpackage.model.exception;
+
+public class ModelClassException extends RuntimeException {
+
+  private static final String ERROR_MESSAGE = "There are some problems related to the entity called %s. Maybe could be caused by required fields or anyOf/oneOf restrictions";
+
+  public ModelClassException(final String modelEntity) {
+    super(String.format(ERROR_MESSAGE, modelEntity));
+  }
+}

--- a/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testExternalRefsGeneration/assets/ModelClassException.java
+++ b/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testExternalRefsGeneration/assets/ModelClassException.java
@@ -1,0 +1,10 @@
+package net.coru.multifileplugin.testapi.model.exception;
+
+public class ModelClassException extends RuntimeException {
+
+  private static final String ERROR_MESSAGE = "There are some problems related to the entity called %s. Maybe could be caused by required fields or anyOf/oneOf restrictions";
+
+  public ModelClassException(final String modelEntity) {
+    super(String.format(ERROR_MESSAGE, modelEntity));
+  }
+}

--- a/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testOverWriteModelTrue/assets/ModelClassException.java
+++ b/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testOverWriteModelTrue/assets/ModelClassException.java
@@ -1,0 +1,10 @@
+package net.coru.multifileplugin.testapi.model.exception;
+
+public class ModelClassException extends RuntimeException {
+
+  private static final String ERROR_MESSAGE = "There are some problems related to the entity called %s. Maybe could be caused by required fields or anyOf/oneOf restrictions";
+
+  public ModelClassException(final String modelEntity) {
+    super(String.format(ERROR_MESSAGE, modelEntity));
+  }
+}

--- a/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testRestClientApiGeneration/assets/ModelClassException.java
+++ b/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testRestClientApiGeneration/assets/ModelClassException.java
@@ -1,0 +1,10 @@
+package net.coru.multifileplugin.testrestclient.model.exception;
+
+public class ModelClassException extends RuntimeException {
+
+  private static final String ERROR_MESSAGE = "There are some problems related to the entity called %s. Maybe could be caused by required fields or anyOf/oneOf restrictions";
+
+  public ModelClassException(final String modelEntity) {
+    super(String.format(ERROR_MESSAGE, modelEntity));
+  }
+}

--- a/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testWebClientApiGeneration/assets/ModelClassException.java
+++ b/src/test/resources/net/coru/api/generator/openapi/integration/test/OpenApiGenerationTest/testWebClientApiGeneration/assets/ModelClassException.java
@@ -1,0 +1,10 @@
+package net.coru.multifileplugin.testwebclient.model.exception;
+
+public class ModelClassException extends RuntimeException {
+
+  private static final String ERROR_MESSAGE = "There are some problems related to the entity called %s. Maybe could be caused by required fields or anyOf/oneOf restrictions";
+
+  public ModelClassException(final String modelEntity) {
+    super(String.format(ERROR_MESSAGE, modelEntity));
+  }
+}


### PR DESCRIPTION
Fixes creation of ModelClassException class. Now it's created only when it's really needed, meaning no Lombok use or there is at least one AnyOf/OneOf defined, and it's always allowed overwriting, because there won't be any changes to it.

Also it's now included in the test where it's needed.

Closes #115 